### PR TITLE
Dcchuck/readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-integration-example
 
-This is a simple example that shows NodeJS to OpenFin integration. We co-deploy a NodeJS service with our OpenFin application (see the [app.json](https://github.com/openfin/node-integration-example/blob/master/public/app.json) file for specifics) and use the Inter Application Bus on both side to demonstrate connectivity.
+This is a simple example that shows NodeJS to OpenFin integration. We co-deploy a NodeJS service with our OpenFin application (see the [app.json](public/app.json) file for specifics) and use the Inter Application Bus on both side to demonstrate connectivity.
 
 ## Running the example
 
@@ -22,7 +22,7 @@ fin.desktop.System.launchExternalProcess({
 , (reason, error) => reject(error));
 ``` 
 
-See the [Gruntfile](https://github.com/openfin/node-integration-example/blob/master/gruntfile.js) for specifics.
+See the [Gruntfile](gruntfile.js) for specifics.
 
 ## Inter Application bus
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This is a simple example that shows NodeJS to OpenFin integration. We co-deploy 
 `npm install && npm start`
 
 ## What is happening ?
-On an `npm start` command the "node-service" folder will be zipped up and moved to the public folder, simulating a remote web server `grunt:connect` will serve the public folder and the OpenFin `grunt:openfin` plugin will launch the node-integration-example application from public/app.json. see the [Gruntfile](https://github.com/openfin/node-integration-example/blob/master/gruntfile.js) for specifics.
+1. On `npm start` the "node-service" folder will be zipped up and moved to the public folder.
+2. Simulating a remote web server, `grunt:connect` will serve the public folder
+3. The OpenFin `grunt:openfin` plugin ([github](https://github.com/openfin/grunt-openfin)) will launch the node-integration-example application from public/app.json. 
 
-On a successfull launch, the contents of the "node-service" folder will be deployed onto OpenFin and launched by `main.js`: 
+On a successfull launch, the contents of the "node-service" folder will be deployed onto OpenFin and launched by [main.js](public/js/main.js): 
 
 ```javascript
 fin.desktop.System.launchExternalProcess({
@@ -19,6 +21,8 @@ fin.desktop.System.launchExternalProcess({
 }, payload => resolve(payload)
 , (reason, error) => reject(error));
 ``` 
+
+See the [Gruntfile](https://github.com/openfin/node-integration-example/blob/master/gruntfile.js) for specifics.
 
 ## Inter Application bus
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # node-integration-example
 
-This is a simple example that shows NodeJS to OpenFin integration. We co-deploy a NodeJS service with our OpenFin application (see the [app.json](public/app,json) file for specifics) and use the Inter Application Bus on both side to demonstrate connectivity.
+This is a simple example that shows NodeJS to OpenFin integration. We co-deploy a NodeJS service with our OpenFin application (see the [app.json](https://github.com/openfin/node-integration-example/blob/master/public/app.json) file for specifics) and use the Inter Application Bus on both side to demonstrate connectivity.
 
 ## Running the example
 
 `npm install && npm start`
 
 ## What is happening ?
-On an `npm start` command the "node-service" folder will be zipped up and moved to the public folder, simulating a remote web server `grunt:connect` will serve the public folder and the OpenFin `grunt:openfin` plugin will launch the node-integration-example application from public/app.json. see the [Gruntfile](Gruntfile.js) for specifics.
+On an `npm start` command the "node-service" folder will be zipped up and moved to the public folder, simulating a remote web server `grunt:connect` will serve the public folder and the OpenFin `grunt:openfin` plugin will launch the node-integration-example application from public/app.json. see the [Gruntfile](https://github.com/openfin/node-integration-example/blob/master/gruntfile.js) for specifics.
 
 On a successfull launch, the contents of the "node-service" folder will be deployed onto OpenFin and launched by `main.js`: 
 
@@ -42,7 +42,7 @@ setInterval(() => {
 }, 1000);
 ```
 
-#### OpenFin side: [main.js](public/main.js)
+#### OpenFin side: [main.js](public/js/main.js)
 ```javascript
 fin.desktop.InterApplicationBus.subscribe(serviceUuid, toWebTopic, function(msg, uuid) {
     messageCtrl.innerText = `Received ${msg.data} from ${uuid}`;


### PR DESCRIPTION
Github markdown needs case sensitive file names & full relative file paths to link correctly. Fixed some non-working links & then broke out the "what is happening" to some bullet points.